### PR TITLE
fix invalid authentication for Sonos devices

### DIFF
--- a/config/packages/unified_notification_system/speech_engine.yaml
+++ b/config/packages/unified_notification_system/speech_engine.yaml
@@ -89,7 +89,7 @@ script:
                 data:
                   media_content_id: "media-source://media_source/local/{{ chime_tone }}"
                   media_content_type: audio/mpeg
-                  announce: false
+                  enqueue: play
                 target:
                   entity_id: "{{ player }}"
 
@@ -101,6 +101,10 @@ script:
 
               - delay:
                   seconds: 3
+
+              - action: media_player.clear_playlist
+                target:
+                  entity_id: "{{ player }}"
 
     - action: media_player.volume_set
       target:


### PR DESCRIPTION
more info here https://community.home-assistant.io/t/can-t-get-media-player-clear-playlist-to-work-for-sonos/706543/25?u=apuglife

> When using play_media to play an mp3 file with enqueue set to “replace” or enqueue not specified the file is played directly and is not added to a queue. Hence there is no queue to clear.
> 
> If you specify “play” as the enqueue attribute, then it’ll add it to the queue.
> 
> A sequence that may work is:
> 
>     clear queue
>     play mp3 with enqueue set to play
>     when done playing clear queue.

